### PR TITLE
Refactor pool spawning logic

### DIFF
--- a/Assets/_Scripts/Utility/TeamColorPersistentPool.cs
+++ b/Assets/_Scripts/Utility/TeamColorPersistentPool.cs
@@ -40,15 +40,15 @@ namespace CosmicShore.Game
             };
         }
 
-        protected override GameObject CreatePoolObject(GameObject prefab)
+        protected override GameObject CreatePoolObject(GameObject prefab, string tag)
         {
-            GameObject obj = base.CreatePoolObject(prefab);
+            GameObject obj = base.CreatePoolObject(prefab, tag);
 
             // Set the material based on the pool's tag
             var renderer = obj.GetComponent<Renderer>();
             if (renderer != null)
             {
-                Teams team = GetTeamFromTag(prefab.tag);
+                Teams team = GetTeamFromTag(tag);
                 Material teamMaterial = new Material(_themeManagerData.GetTeamExplodingBlockMaterial(team));
                 renderer.material = teamMaterial;
             }
@@ -75,16 +75,16 @@ namespace CosmicShore.Game
 
             // Create team specific pools
             fossilBlockPrefab.tag = GetTagForTeam(Teams.Jade);
-            AddConfigData(fossilBlockPrefab, poolSizePerTeam);
+            AddConfigData(fossilBlockPrefab, poolSizePerTeam, fossilBlockPrefab.tag);
 
             fossilBlockPrefab.tag = GetTagForTeam(Teams.Ruby);
-            AddConfigData(fossilBlockPrefab, poolSizePerTeam);
+            AddConfigData(fossilBlockPrefab, poolSizePerTeam, fossilBlockPrefab.tag);
 
             fossilBlockPrefab.tag = GetTagForTeam(Teams.Gold);
-            AddConfigData(fossilBlockPrefab, poolSizePerTeam);
+            AddConfigData(fossilBlockPrefab, poolSizePerTeam, fossilBlockPrefab.tag);
 
             fossilBlockPrefab.tag = GetTagForTeam(Teams.Blue);
-            AddConfigData(fossilBlockPrefab, poolSizePerTeam);
+            AddConfigData(fossilBlockPrefab, poolSizePerTeam, fossilBlockPrefab.tag);
 
             // Restore original tag
             fossilBlockPrefab.tag = originalTag;


### PR DESCRIPTION
## Summary
- keep extra objects available when pools run dry
- log when pools are expanded during spawning
- retain prefab tags per pool to support team colors

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_685c4fd6e69883288e90f3adbfcb70b0