### PR TITLE
Fix missing ThemeManagerData in projectiles

### DIFF
--- a/Assets/_Prefabs/Projectile/AOEFlowerCreation.prefab
+++ b/Assets/_Prefabs/Projectile/AOEFlowerCreation.prefab
@@ -54,3 +54,4 @@ MonoBehaviour:
   ringCount: 3
   radius: 30
   blockScale: {x: 0, y: 0, z: 0}
+  _themeManagerData: {fileID: 11400000, guid: d45a23e6bd2da304988606fba6c97628, type: 2}

--- a/Assets/_Prefabs/Projectile/FalconProjectile.prefab
+++ b/Assets/_Prefabs/Projectile/FalconProjectile.prefab
@@ -4919,3 +4919,4 @@ MonoBehaviour:
   spike: 0
   growthRate: 1
   friendlyFire: 1
+  _themeManagerData: {fileID: 11400000, guid: d45a23e6bd2da304988606fba6c97628, type: 2}

--- a/Assets/_Prefabs/Projectile/Projectile.prefab
+++ b/Assets/_Prefabs/Projectile/Projectile.prefab
@@ -4914,3 +4914,4 @@ MonoBehaviour:
   Ship: {fileID: 0}
   trailBlockImpactEffects: 07000000
   shipImpactEffects: 020000000300000001000000
+  _themeManagerData: {fileID: 11400000, guid: d45a23e6bd2da304988606fba6c97628, type: 2}

--- a/Assets/_Prefabs/Projectile/ProjectileFX.prefab
+++ b/Assets/_Prefabs/Projectile/ProjectileFX.prefab
@@ -4965,3 +4965,4 @@ MonoBehaviour:
   spike: 0
   growthRate: 1
   friendlyFire: 1
+  _themeManagerData: {fileID: 11400000, guid: d45a23e6bd2da304988606fba6c97628, type: 2}

--- a/Assets/_Prefabs/Projectile/SkyBurstProjectile.prefab
+++ b/Assets/_Prefabs/Projectile/SkyBurstProjectile.prefab
@@ -4886,6 +4886,7 @@ MonoBehaviour:
   spike: 0
   growthRate: 1
   friendlyFire: 1
+  _themeManagerData: {fileID: 11400000, guid: d45a23e6bd2da304988606fba6c97628, type: 2}
   AOEPrefabs:
   - {fileID: 447888847298330991, guid: b6aa24b5cd6a7f24c9f24c32c20eba91, type: 3}
   - {fileID: 3479271500403630839, guid: 4a855af160021d241b8c1ac70cf2d792, type: 3}

--- a/Assets/_Prefabs/Projectile/SparrowProjectile.prefab
+++ b/Assets/_Prefabs/Projectile/SparrowProjectile.prefab
@@ -162,3 +162,4 @@ MonoBehaviour:
   spike: 0
   growthRate: 1
   friendlyFire: 1
+  _themeManagerData: {fileID: 11400000, guid: d45a23e6bd2da304988606fba6c97628, type: 2}


### PR DESCRIPTION
## Summary
- include the ThemeManagerDataContainer reference for `AOEFlowerCreation` prefab
- link `SkyBurstProjectile` to the ThemeManagerDataContainer asset

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685c86e17ec88328b0eee02509bf52df