### PR TITLE
Add ScriptableObjects for CrystalImpact effects

### DIFF
--- a/Assets/_SO_Assets/Effects.meta
+++ b/Assets/_SO_Assets/Effects.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e0ab7823e7e56c4616cf22a5e59ae16d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_SO_Assets/Effects/ActivateTrailBlockEffectSO.asset
+++ b/Assets/_SO_Assets/Effects/ActivateTrailBlockEffectSO.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7e24baad8f44a00409ae649bdff6a4a6, type: 3}
+  m_Name: ActivateTrailBlockEffectSO
+  m_EditorClassIdentifier:

--- a/Assets/_SO_Assets/Effects/ActivateTrailBlockEffectSO.asset.meta
+++ b/Assets/_SO_Assets/Effects/ActivateTrailBlockEffectSO.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: db4642c3b666125b6b10739d512d7d4e
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_SO_Assets/Effects/AlignEffectSO.asset
+++ b/Assets/_SO_Assets/Effects/AlignEffectSO.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6beb070feabc4224c8dc64ae478c7b04, type: 3}
+  m_Name: AlignEffectSO
+  m_EditorClassIdentifier:

--- a/Assets/_SO_Assets/Effects/AlignEffectSO.asset.meta
+++ b/Assets/_SO_Assets/Effects/AlignEffectSO.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9655b3c838d5086016d1bd070b0ba3a4
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_SO_Assets/Effects/AreaOfEffectExplosionEffectSO.asset
+++ b/Assets/_SO_Assets/Effects/AreaOfEffectExplosionEffectSO.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9f5eeb6605e14d340aac43c555dbc309, type: 3}
+  m_Name: AreaOfEffectExplosionEffectSO
+  m_EditorClassIdentifier:

--- a/Assets/_SO_Assets/Effects/AreaOfEffectExplosionEffectSO.asset.meta
+++ b/Assets/_SO_Assets/Effects/AreaOfEffectExplosionEffectSO.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f6b2725ba1ff2bada6953c0932d90638
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_SO_Assets/Effects/AttachEffectSO.asset
+++ b/Assets/_SO_Assets/Effects/AttachEffectSO.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ed6e4bfb6a0d5d54fa9133bcceab2dc0, type: 3}
+  m_Name: AttachEffectSO
+  m_EditorClassIdentifier:

--- a/Assets/_SO_Assets/Effects/AttachEffectSO.asset.meta
+++ b/Assets/_SO_Assets/Effects/AttachEffectSO.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 050a3cf0a379d6b60642a71ca050dad4
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_SO_Assets/Effects/BoostEffectSO.asset
+++ b/Assets/_SO_Assets/Effects/BoostEffectSO.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75165082da91555428e9b9d6b85de7e1, type: 3}
+  m_Name: BoostEffectSO
+  m_EditorClassIdentifier:

--- a/Assets/_SO_Assets/Effects/BoostEffectSO.asset.meta
+++ b/Assets/_SO_Assets/Effects/BoostEffectSO.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b1d5dab71f0f51462385f409cc1c050e
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_SO_Assets/Effects/BounceEffectSO.asset
+++ b/Assets/_SO_Assets/Effects/BounceEffectSO.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c267653e0fc4fbb4b80b038a14fdccab, type: 3}
+  m_Name: BounceEffectSO
+  m_EditorClassIdentifier:

--- a/Assets/_SO_Assets/Effects/BounceEffectSO.asset.meta
+++ b/Assets/_SO_Assets/Effects/BounceEffectSO.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 975067fa2a3b229a073258f6687cd539
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_SO_Assets/Effects/ChangeResourceEffectSO.asset
+++ b/Assets/_SO_Assets/Effects/ChangeResourceEffectSO.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0a83897bc497f0c4da40e63dc3f623a2, type: 3}
+  m_Name: ChangeResourceEffectSO
+  m_EditorClassIdentifier:

--- a/Assets/_SO_Assets/Effects/ChangeResourceEffectSO.asset.meta
+++ b/Assets/_SO_Assets/Effects/ChangeResourceEffectSO.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8d5123e8830cc0fcc6bcbccf58149e42
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_SO_Assets/Effects/CharmEffectSO.asset
+++ b/Assets/_SO_Assets/Effects/CharmEffectSO.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4445915c77472b8449904f2b361380f6, type: 3}
+  m_Name: CharmEffectSO
+  m_EditorClassIdentifier:

--- a/Assets/_SO_Assets/Effects/CharmEffectSO.asset.meta
+++ b/Assets/_SO_Assets/Effects/CharmEffectSO.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b1e5f1b1d17248431d8d8da2892629b8
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_SO_Assets/Effects/DeactivateTrailBlockEffectSO.asset
+++ b/Assets/_SO_Assets/Effects/DeactivateTrailBlockEffectSO.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f047dd0faf1722c498b63eb23242e2ac, type: 3}
+  m_Name: DeactivateTrailBlockEffectSO
+  m_EditorClassIdentifier:

--- a/Assets/_SO_Assets/Effects/DeactivateTrailBlockEffectSO.asset.meta
+++ b/Assets/_SO_Assets/Effects/DeactivateTrailBlockEffectSO.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0e7b0dde7d9bc7290483d7daab79e38b
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_SO_Assets/Effects/DebuffSpeedEffectSO.asset
+++ b/Assets/_SO_Assets/Effects/DebuffSpeedEffectSO.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8ac594798c951da4182b02940e416d30, type: 3}
+  m_Name: DebuffSpeedEffectSO
+  m_EditorClassIdentifier:

--- a/Assets/_SO_Assets/Effects/DebuffSpeedEffectSO.asset.meta
+++ b/Assets/_SO_Assets/Effects/DebuffSpeedEffectSO.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ac862d73e3ada036cb8a50fe6bb55e81
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_SO_Assets/Effects/DecrementLevelEffectSO.asset
+++ b/Assets/_SO_Assets/Effects/DecrementLevelEffectSO.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 18c3c15fac406b64193bcfe83a483964, type: 3}
+  m_Name: DecrementLevelEffectSO
+  m_EditorClassIdentifier:

--- a/Assets/_SO_Assets/Effects/DecrementLevelEffectSO.asset.meta
+++ b/Assets/_SO_Assets/Effects/DecrementLevelEffectSO.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 59e3ff98e8cbeea80865757f029db59e
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_SO_Assets/Effects/DrainAmmoEffectSO.asset
+++ b/Assets/_SO_Assets/Effects/DrainAmmoEffectSO.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6bfa6ea525154ba790db086493eb0e27, type: 3}
+  m_Name: DrainAmmoEffectSO
+  m_EditorClassIdentifier:

--- a/Assets/_SO_Assets/Effects/DrainAmmoEffectSO.asset.meta
+++ b/Assets/_SO_Assets/Effects/DrainAmmoEffectSO.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9bc36cbf132b4f0581c4fec55f3e1732
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_SO_Assets/Effects/DrainHalfAmmoEffectSO.asset
+++ b/Assets/_SO_Assets/Effects/DrainHalfAmmoEffectSO.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8854387e3c744c046af052264e28bf1f, type: 3}
+  m_Name: DrainHalfAmmoEffectSO
+  m_EditorClassIdentifier:

--- a/Assets/_SO_Assets/Effects/DrainHalfAmmoEffectSO.asset.meta
+++ b/Assets/_SO_Assets/Effects/DrainHalfAmmoEffectSO.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: acd7873897970a2eb8c02e5e298c8c16
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_SO_Assets/Effects/ExplodeEffectSO.asset
+++ b/Assets/_SO_Assets/Effects/ExplodeEffectSO.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7e759460591e45a47aa8234829107c7e, type: 3}
+  m_Name: ExplodeEffectSO
+  m_EditorClassIdentifier:

--- a/Assets/_SO_Assets/Effects/ExplodeEffectSO.asset.meta
+++ b/Assets/_SO_Assets/Effects/ExplodeEffectSO.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 89f84fbba3cfe336d229d942c07fd521
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_SO_Assets/Effects/FXEffectSO.asset
+++ b/Assets/_SO_Assets/Effects/FXEffectSO.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bfdbfc260ef76fb4ba4ddce4cec209ff, type: 3}
+  m_Name: FXEffectSO
+  m_EditorClassIdentifier:

--- a/Assets/_SO_Assets/Effects/FXEffectSO.asset.meta
+++ b/Assets/_SO_Assets/Effects/FXEffectSO.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 222210e40a351d5258b1ce66220b8453
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_SO_Assets/Effects/FeelDangerEffectSO.asset
+++ b/Assets/_SO_Assets/Effects/FeelDangerEffectSO.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 268c1d27ad33f87479a6986948cb6d76, type: 3}
+  m_Name: FeelDangerEffectSO
+  m_EditorClassIdentifier:

--- a/Assets/_SO_Assets/Effects/FeelDangerEffectSO.asset.meta
+++ b/Assets/_SO_Assets/Effects/FeelDangerEffectSO.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5fdd42bc7ecaccf6f945a866337ccd20
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_SO_Assets/Effects/FillChargeEffectSO.asset
+++ b/Assets/_SO_Assets/Effects/FillChargeEffectSO.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bd3468e4bb73477a8d3e256d1b8b171b, type: 3}
+  m_Name: FillChargeEffectSO
+  m_EditorClassIdentifier:

--- a/Assets/_SO_Assets/Effects/FillChargeEffectSO.asset.meta
+++ b/Assets/_SO_Assets/Effects/FillChargeEffectSO.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6f45ce20a66144d39d6e8eb476276e4b
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_SO_Assets/Effects/FireEffectSO.asset
+++ b/Assets/_SO_Assets/Effects/FireEffectSO.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 899251cd0eeda884f99e6dbaca114c89, type: 3}
+  m_Name: FireEffectSO
+  m_EditorClassIdentifier:

--- a/Assets/_SO_Assets/Effects/FireEffectSO.asset.meta
+++ b/Assets/_SO_Assets/Effects/FireEffectSO.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 88f73ada5fdeb9e2df75cc5ce558689b
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_SO_Assets/Effects/GainFullAmmoEffectSO.asset
+++ b/Assets/_SO_Assets/Effects/GainFullAmmoEffectSO.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 362390199bd04b35ae7588181db6ec91, type: 3}
+  m_Name: GainFullAmmoEffectSO
+  m_EditorClassIdentifier:

--- a/Assets/_SO_Assets/Effects/GainFullAmmoEffectSO.asset.meta
+++ b/Assets/_SO_Assets/Effects/GainFullAmmoEffectSO.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 63cf794e5083466d82404bc3571435d4
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_SO_Assets/Effects/GainOneThirdMaxAmmoEffectSO.asset
+++ b/Assets/_SO_Assets/Effects/GainOneThirdMaxAmmoEffectSO.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 44a50db5ac054019803174df0a57a99c, type: 3}
+  m_Name: GainOneThirdMaxAmmoEffectSO
+  m_EditorClassIdentifier:

--- a/Assets/_SO_Assets/Effects/GainOneThirdMaxAmmoEffectSO.asset.meta
+++ b/Assets/_SO_Assets/Effects/GainOneThirdMaxAmmoEffectSO.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 19b83c2d368847d9acc3c236fc0f6236
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_SO_Assets/Effects/GainResourceByVolumeEffectSO.asset
+++ b/Assets/_SO_Assets/Effects/GainResourceByVolumeEffectSO.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5932e74ba06840345a7813c5df88e984, type: 3}
+  m_Name: GainResourceByVolumeEffectSO
+  m_EditorClassIdentifier:

--- a/Assets/_SO_Assets/Effects/GainResourceByVolumeEffectSO.asset.meta
+++ b/Assets/_SO_Assets/Effects/GainResourceByVolumeEffectSO.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 77d2f40630f37ed6b2e8c73c4cd59430
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_SO_Assets/Effects/GainResourceEffectSO.asset
+++ b/Assets/_SO_Assets/Effects/GainResourceEffectSO.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 85f8f1880ac993c4ba7a9cf9090ca21b, type: 3}
+  m_Name: GainResourceEffectSO
+  m_EditorClassIdentifier:

--- a/Assets/_SO_Assets/Effects/GainResourceEffectSO.asset.meta
+++ b/Assets/_SO_Assets/Effects/GainResourceEffectSO.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 52a271623aba796f52b611e6da56b050
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_SO_Assets/Effects/IncrementLevelEffectSO.asset
+++ b/Assets/_SO_Assets/Effects/IncrementLevelEffectSO.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: da9d46692bdc4790b0708a18eb0f50cd, type: 3}
+  m_Name: IncrementLevelEffectSO
+  m_EditorClassIdentifier:

--- a/Assets/_SO_Assets/Effects/IncrementLevelEffectSO.asset.meta
+++ b/Assets/_SO_Assets/Effects/IncrementLevelEffectSO.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5964499400614a10b98c1fff0f660814
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_SO_Assets/Effects/KnockbackEffectSO.asset
+++ b/Assets/_SO_Assets/Effects/KnockbackEffectSO.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d2efd01a8673cb84ea3bf04ec939716b, type: 3}
+  m_Name: KnockbackEffectSO
+  m_EditorClassIdentifier:

--- a/Assets/_SO_Assets/Effects/KnockbackEffectSO.asset.meta
+++ b/Assets/_SO_Assets/Effects/KnockbackEffectSO.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9812496630d0c2a2c3ffc7be7340c460
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_SO_Assets/Effects/OnlyBuffSpeedEffectSO.asset
+++ b/Assets/_SO_Assets/Effects/OnlyBuffSpeedEffectSO.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 27fd7d2360f418347be79425f494cadd, type: 3}
+  m_Name: OnlyBuffSpeedEffectSO
+  m_EditorClassIdentifier:

--- a/Assets/_SO_Assets/Effects/OnlyBuffSpeedEffectSO.asset.meta
+++ b/Assets/_SO_Assets/Effects/OnlyBuffSpeedEffectSO.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5d56e835918f6594f7827d127caa9c23
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_SO_Assets/Effects/PlayFakeCrystalHapticsEffectSO.asset
+++ b/Assets/_SO_Assets/Effects/PlayFakeCrystalHapticsEffectSO.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bbf0516fd9eb4cb18c32e44cbf4c6ab6, type: 3}
+  m_Name: PlayFakeCrystalHapticsEffectSO
+  m_EditorClassIdentifier:

--- a/Assets/_SO_Assets/Effects/PlayFakeCrystalHapticsEffectSO.asset.meta
+++ b/Assets/_SO_Assets/Effects/PlayFakeCrystalHapticsEffectSO.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c048f2ca53b44eb0bc6b0a67a081a528
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_SO_Assets/Effects/PlayHapticsEffectSO.asset
+++ b/Assets/_SO_Assets/Effects/PlayHapticsEffectSO.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 988338ad26d138d4bad865024ec86c7d, type: 3}
+  m_Name: PlayHapticsEffectSO
+  m_EditorClassIdentifier:

--- a/Assets/_SO_Assets/Effects/PlayHapticsEffectSO.asset.meta
+++ b/Assets/_SO_Assets/Effects/PlayHapticsEffectSO.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ea7db8b575671993a4b5e488c72ba74b
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_SO_Assets/Effects/RedirectEffectSO.asset
+++ b/Assets/_SO_Assets/Effects/RedirectEffectSO.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 82503340fd407d945982f464adef56fb, type: 3}
+  m_Name: RedirectEffectSO
+  m_EditorClassIdentifier:

--- a/Assets/_SO_Assets/Effects/RedirectEffectSO.asset.meta
+++ b/Assets/_SO_Assets/Effects/RedirectEffectSO.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 31c28d0f15ed15642862dae04cddbee5
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_SO_Assets/Effects/ReduceSpeedEffectSO.asset
+++ b/Assets/_SO_Assets/Effects/ReduceSpeedEffectSO.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0c3aa12a836e4b578dd14aaeb3c70632, type: 3}
+  m_Name: ReduceSpeedEffectSO
+  m_EditorClassIdentifier:

--- a/Assets/_SO_Assets/Effects/ReduceSpeedEffectSO.asset.meta
+++ b/Assets/_SO_Assets/Effects/ReduceSpeedEffectSO.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3027d58c7fe247b3ac953f44775b78ac
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_SO_Assets/Effects/ScaleGapEffectSO.asset
+++ b/Assets/_SO_Assets/Effects/ScaleGapEffectSO.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 45dd86efa5b8da34a843635cf482f623, type: 3}
+  m_Name: ScaleGapEffectSO
+  m_EditorClassIdentifier:

--- a/Assets/_SO_Assets/Effects/ScaleGapEffectSO.asset.meta
+++ b/Assets/_SO_Assets/Effects/ScaleGapEffectSO.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e9fe804bd3a44981b321e84b456612b8
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_SO_Assets/Effects/ScaleHapticWithDistanceEffectSO.asset
+++ b/Assets/_SO_Assets/Effects/ScaleHapticWithDistanceEffectSO.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f574b3924c2f25044bc7769c55c6ef3c, type: 3}
+  m_Name: ScaleHapticWithDistanceEffectSO
+  m_EditorClassIdentifier:

--- a/Assets/_SO_Assets/Effects/ScaleHapticWithDistanceEffectSO.asset.meta
+++ b/Assets/_SO_Assets/Effects/ScaleHapticWithDistanceEffectSO.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7c901bfac25fec2e47453a11d4333b4c
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_SO_Assets/Effects/ScalePitchAndYawEffectSO.asset
+++ b/Assets/_SO_Assets/Effects/ScalePitchAndYawEffectSO.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 097838399938414458c6648c46348d5d, type: 3}
+  m_Name: ScalePitchAndYawEffectSO
+  m_EditorClassIdentifier:

--- a/Assets/_SO_Assets/Effects/ScalePitchAndYawEffectSO.asset.meta
+++ b/Assets/_SO_Assets/Effects/ScalePitchAndYawEffectSO.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 79805e8d6b85f34f9c9f3b0c94d296cd
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_SO_Assets/Effects/ScaleTrailAndCameraEffectSO.asset
+++ b/Assets/_SO_Assets/Effects/ScaleTrailAndCameraEffectSO.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e76c1afed679b3949b0674bc826d3924, type: 3}
+  m_Name: ScaleTrailAndCameraEffectSO
+  m_EditorClassIdentifier:

--- a/Assets/_SO_Assets/Effects/ScaleTrailAndCameraEffectSO.asset.meta
+++ b/Assets/_SO_Assets/Effects/ScaleTrailAndCameraEffectSO.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c859df0e2ad7e79f870557a541318a40
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_SO_Assets/Effects/ShieldEffectSO.asset
+++ b/Assets/_SO_Assets/Effects/ShieldEffectSO.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9bf27317cd09e9e439ceec83121fdbdf, type: 3}
+  m_Name: ShieldEffectSO
+  m_EditorClassIdentifier:

--- a/Assets/_SO_Assets/Effects/ShieldEffectSO.asset.meta
+++ b/Assets/_SO_Assets/Effects/ShieldEffectSO.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 35aca29238ed39654ecf95c32be40513
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_SO_Assets/Effects/SpinAroundEffectSO.asset
+++ b/Assets/_SO_Assets/Effects/SpinAroundEffectSO.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d39b2a60f9c810048bd3a7ebd779feab, type: 3}
+  m_Name: SpinAroundEffectSO
+  m_EditorClassIdentifier:

--- a/Assets/_SO_Assets/Effects/SpinAroundEffectSO.asset.meta
+++ b/Assets/_SO_Assets/Effects/SpinAroundEffectSO.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2e278df34f7acd385365a6522f8e7ddc
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_SO_Assets/Effects/StealCrystalEffectSO.asset
+++ b/Assets/_SO_Assets/Effects/StealCrystalEffectSO.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 79e6224c0f3645b283fc5c8db62f8c1a, type: 3}
+  m_Name: StealCrystalEffectSO
+  m_EditorClassIdentifier:

--- a/Assets/_SO_Assets/Effects/StealCrystalEffectSO.asset.meta
+++ b/Assets/_SO_Assets/Effects/StealCrystalEffectSO.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5c0e944f064a419198a3ed1283ab26d1
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_SO_Assets/Effects/StealEffectSO.asset
+++ b/Assets/_SO_Assets/Effects/StealEffectSO.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8dedda946a4482447ab295ea03a072da, type: 3}
+  m_Name: StealEffectSO
+  m_EditorClassIdentifier:

--- a/Assets/_SO_Assets/Effects/StealEffectSO.asset.meta
+++ b/Assets/_SO_Assets/Effects/StealEffectSO.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 72cd3deae4a3ed8e37f35b3c5534448d
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_SO_Assets/Effects/StopEffectSO.asset
+++ b/Assets/_SO_Assets/Effects/StopEffectSO.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: edab5b363867a9f4c961e3242df24b96, type: 3}
+  m_Name: StopEffectSO
+  m_EditorClassIdentifier:

--- a/Assets/_SO_Assets/Effects/StopEffectSO.asset.meta
+++ b/Assets/_SO_Assets/Effects/StopEffectSO.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6eefd7a88155436fbf37f16d8662943a
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_SO_Assets/Effects/StunEffectSO.asset
+++ b/Assets/_SO_Assets/Effects/StunEffectSO.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6de00463aac3e754e88fe44d93dc2bd4, type: 3}
+  m_Name: StunEffectSO
+  m_EditorClassIdentifier:

--- a/Assets/_SO_Assets/Effects/StunEffectSO.asset.meta
+++ b/Assets/_SO_Assets/Effects/StunEffectSO.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7a5c6ccc0c9cabaebdb76fa302d64fd6
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_SO_Assets/Effects/TrailSpawnerCooldownEffectSO.asset
+++ b/Assets/_SO_Assets/Effects/TrailSpawnerCooldownEffectSO.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f92ee2a11b7f9304eab2548624cdd7e7, type: 3}
+  m_Name: TrailSpawnerCooldownEffectSO
+  m_EditorClassIdentifier:

--- a/Assets/_SO_Assets/Effects/TrailSpawnerCooldownEffectSO.asset.meta
+++ b/Assets/_SO_Assets/Effects/TrailSpawnerCooldownEffectSO.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f5953fa836edea4a271739c5d600df33
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_SO_Assets/Effects/VizualizeDistanceEffectSO.asset
+++ b/Assets/_SO_Assets/Effects/VizualizeDistanceEffectSO.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1e826eea31d88af479cf199f1f079e76, type: 3}
+  m_Name: VizualizeDistanceEffectSO
+  m_EditorClassIdentifier:

--- a/Assets/_SO_Assets/Effects/VizualizeDistanceEffectSO.asset.meta
+++ b/Assets/_SO_Assets/Effects/VizualizeDistanceEffectSO.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7e06ff1ef6d2045ca0c68b6f6f916ae0
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Scripts/Game/Effects/DrainAmmoEffectSO.cs
+++ b/Assets/_Scripts/Game/Effects/DrainAmmoEffectSO.cs
@@ -1,0 +1,13 @@
+using UnityEngine;
+
+namespace CosmicShore.Game
+{
+    [CreateAssetMenu(fileName = "DrainAmmoImpactEffect", menuName = "ScriptableObjects/Impact Effects/DrainAmmoImpactEffectSO")]
+    public class DrainAmmoEffectSO : BaseImpactEffectSO
+    {
+        public override void Execute(ImpactContext context)
+        {
+
+        }
+    }
+}

--- a/Assets/_Scripts/Game/Effects/DrainAmmoEffectSO.cs.meta
+++ b/Assets/_Scripts/Game/Effects/DrainAmmoEffectSO.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6bfa6ea525154ba790db086493eb0e27

--- a/Assets/_Scripts/Game/Effects/FillChargeEffectSO.cs
+++ b/Assets/_Scripts/Game/Effects/FillChargeEffectSO.cs
@@ -1,0 +1,13 @@
+using UnityEngine;
+
+namespace CosmicShore.Game
+{
+    [CreateAssetMenu(fileName = "FillChargeImpactEffect", menuName = "ScriptableObjects/Impact Effects/FillChargeImpactEffectSO")]
+    public class FillChargeEffectSO : BaseImpactEffectSO
+    {
+        public override void Execute(ImpactContext context)
+        {
+
+        }
+    }
+}

--- a/Assets/_Scripts/Game/Effects/FillChargeEffectSO.cs.meta
+++ b/Assets/_Scripts/Game/Effects/FillChargeEffectSO.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: bd3468e4bb73477a8d3e256d1b8b171b

--- a/Assets/_Scripts/Game/Effects/GainFullAmmoEffectSO.cs
+++ b/Assets/_Scripts/Game/Effects/GainFullAmmoEffectSO.cs
@@ -1,0 +1,13 @@
+using UnityEngine;
+
+namespace CosmicShore.Game
+{
+    [CreateAssetMenu(fileName = "GainFullAmmoImpactEffect", menuName = "ScriptableObjects/Impact Effects/GainFullAmmoImpactEffectSO")]
+    public class GainFullAmmoEffectSO : BaseImpactEffectSO
+    {
+        public override void Execute(ImpactContext context)
+        {
+
+        }
+    }
+}

--- a/Assets/_Scripts/Game/Effects/GainFullAmmoEffectSO.cs.meta
+++ b/Assets/_Scripts/Game/Effects/GainFullAmmoEffectSO.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 362390199bd04b35ae7588181db6ec91

--- a/Assets/_Scripts/Game/Effects/GainOneThirdMaxAmmoEffectSO.cs
+++ b/Assets/_Scripts/Game/Effects/GainOneThirdMaxAmmoEffectSO.cs
@@ -1,0 +1,13 @@
+using UnityEngine;
+
+namespace CosmicShore.Game
+{
+    [CreateAssetMenu(fileName = "GainOneThirdMaxAmmoImpactEffect", menuName = "ScriptableObjects/Impact Effects/GainOneThirdMaxAmmoImpactEffectSO")]
+    public class GainOneThirdMaxAmmoEffectSO : BaseImpactEffectSO
+    {
+        public override void Execute(ImpactContext context)
+        {
+
+        }
+    }
+}

--- a/Assets/_Scripts/Game/Effects/GainOneThirdMaxAmmoEffectSO.cs.meta
+++ b/Assets/_Scripts/Game/Effects/GainOneThirdMaxAmmoEffectSO.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 44a50db5ac054019803174df0a57a99c

--- a/Assets/_Scripts/Game/Effects/IncrementLevelEffectSO.cs
+++ b/Assets/_Scripts/Game/Effects/IncrementLevelEffectSO.cs
@@ -1,0 +1,13 @@
+using UnityEngine;
+
+namespace CosmicShore.Game
+{
+    [CreateAssetMenu(fileName = "IncrementLevelImpactEffect", menuName = "ScriptableObjects/Impact Effects/IncrementLevelImpactEffectSO")]
+    public class IncrementLevelEffectSO : BaseImpactEffectSO
+    {
+        public override void Execute(ImpactContext context)
+        {
+
+        }
+    }
+}

--- a/Assets/_Scripts/Game/Effects/IncrementLevelEffectSO.cs.meta
+++ b/Assets/_Scripts/Game/Effects/IncrementLevelEffectSO.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: da9d46692bdc4790b0708a18eb0f50cd

--- a/Assets/_Scripts/Game/Effects/PlayFakeCrystalHapticsEffectSO.cs
+++ b/Assets/_Scripts/Game/Effects/PlayFakeCrystalHapticsEffectSO.cs
@@ -1,0 +1,13 @@
+using UnityEngine;
+
+namespace CosmicShore.Game
+{
+    [CreateAssetMenu(fileName = "PlayFakeCrystalHapticsImpactEffect", menuName = "ScriptableObjects/Impact Effects/PlayFakeCrystalHapticsImpactEffectSO")]
+    public class PlayFakeCrystalHapticsEffectSO : BaseImpactEffectSO
+    {
+        public override void Execute(ImpactContext context)
+        {
+
+        }
+    }
+}

--- a/Assets/_Scripts/Game/Effects/PlayFakeCrystalHapticsEffectSO.cs.meta
+++ b/Assets/_Scripts/Game/Effects/PlayFakeCrystalHapticsEffectSO.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: bbf0516fd9eb4cb18c32e44cbf4c6ab6

--- a/Assets/_Scripts/Game/Effects/ReduceSpeedEffectSO.cs
+++ b/Assets/_Scripts/Game/Effects/ReduceSpeedEffectSO.cs
@@ -1,0 +1,13 @@
+using UnityEngine;
+
+namespace CosmicShore.Game
+{
+    [CreateAssetMenu(fileName = "ReduceSpeedImpactEffect", menuName = "ScriptableObjects/Impact Effects/ReduceSpeedImpactEffectSO")]
+    public class ReduceSpeedEffectSO : BaseImpactEffectSO
+    {
+        public override void Execute(ImpactContext context)
+        {
+
+        }
+    }
+}

--- a/Assets/_Scripts/Game/Effects/ReduceSpeedEffectSO.cs.meta
+++ b/Assets/_Scripts/Game/Effects/ReduceSpeedEffectSO.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 0c3aa12a836e4b578dd14aaeb3c70632

--- a/Assets/_Scripts/Game/Effects/StealCrystalEffectSO.cs
+++ b/Assets/_Scripts/Game/Effects/StealCrystalEffectSO.cs
@@ -1,0 +1,13 @@
+using UnityEngine;
+
+namespace CosmicShore.Game
+{
+    [CreateAssetMenu(fileName = "StealCrystalImpactEffect", menuName = "ScriptableObjects/Impact Effects/StealCrystalImpactEffectSO")]
+    public class StealCrystalEffectSO : BaseImpactEffectSO
+    {
+        public override void Execute(ImpactContext context)
+        {
+
+        }
+    }
+}

--- a/Assets/_Scripts/Game/Effects/StealCrystalEffectSO.cs.meta
+++ b/Assets/_Scripts/Game/Effects/StealCrystalEffectSO.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 79e6224c0f3645b283fc5c8db62f8c1a


### PR DESCRIPTION
## Summary
- add new SO scripts for each `CrystalImpactEffects` enum
- generate SO assets for the new effect types

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68622c4255088328a6e6d39cc6528f53